### PR TITLE
Allow BEM

### DIFF
--- a/config/lint/scss.yml
+++ b/config/lint/scss.yml
@@ -103,8 +103,7 @@ linters:
 
   SelectorFormat:
     enabled: true
-    convention: hyphenated_lowercase
-    class_convention: hyphenated_lowercase
+    convention: hyphenated_BEM
 
   Shorthand:
     enabled: true


### PR DESCRIPTION
Awaiting full BEM implementation (#755), let's at least allow BEM as `SelectorFormat` to stimulate the use of BEM in Sphynx projects.