### PR TITLE
Remove medium_large image size

### DIFF
--- a/lib/classes/Media.php
+++ b/lib/classes/Media.php
@@ -17,9 +17,6 @@ final class Media
         update_option('medium_size_w', 360);
         update_option('medium_size_h', '');
 
-        update_option('medium_large_size_w', 0);
-        update_option('medium_large_size_h', 0);
-
         update_option('large_size_w', 840);
         update_option('large_size_h', '');
 

--- a/lib/classes/Media.php
+++ b/lib/classes/Media.php
@@ -17,6 +17,9 @@ final class Media
         update_option('medium_size_w', 360);
         update_option('medium_size_h', '');
 
+        update_option('medium_large_size_w', 0);
+        update_option('medium_large_size_h', 0);
+
         update_option('large_size_w', 840);
         update_option('large_size_h', '');
 

--- a/lib/classes/Media.php
+++ b/lib/classes/Media.php
@@ -6,6 +6,7 @@ final class Media
     public function __construct()
     {
         add_action('after_switch_theme', array($this, 'defaults'));
+        add_filter('intermediate_image_sizes_advanced', array($this, 'removeMediumLarge'));
         add_filter('embed_oembed_html', array($this, 'videoEmbed'));
     }
 
@@ -21,6 +22,15 @@ final class Media
         update_option('large_size_h', '');
 
         update_option('image_default_link_type', 'file');
+    }
+
+    public function removeMediumLarge($sizes)
+    {
+        if (isset($sizes['medium_large'])) {
+            unset($sizes['medium_large']);
+        }
+
+        return $sizes;
     }
 
     public function videoEmbed($html)


### PR DESCRIPTION
Fixes #781 

Unfortunately `remove_image_size('medium_large')` does not work for this default image size (see: https://wordpress.stackexchange.com/questions/251789/prevent-wordpress-from-generating-medium-large-768px-size-of-image-uploads). 

So I removed it by setting the width height to 0 (see: http://owltools.io/tutorial/delete-default-medium-large-thumbnail-size-wordpress/).